### PR TITLE
changed l_mpi-rt location to internal location

### DIFF
--- a/ks/azure/centos72-hpc.ks
+++ b/ks/azure/centos72-hpc.ks
@@ -161,7 +161,7 @@ EOF
 # Install Intel MPI
 MPI="l_mpi-rt_p_5.1.3.181"
 CFG="IntelMPI-silent.cfg"
-curl -so /tmp/${MPI}.tgz http://olmirror.openlogic.com/pub/azure/${MPI}.tgz  ## Internal link to MPI package
+curl -so /tmp/${MPI}.tgz http://192.168.40.171/azure/${MPI}.tgz  ## Internal link to MPI package
 curl -so /tmp/${CFG} https://raw.githubusercontent.com/szarkos/AzureBuildCentOS/master/config/azure/${CFG}
 tar -C /tmp -zxf /tmp/${MPI}.tgz
 /tmp/${MPI}/install.sh --silent /tmp/${CFG}


### PR DESCRIPTION
changed olmirror.openlogic.com to 192.168.40.171.  This is an internal machine accessible from the hyper-v machine that creates the images for Azure.